### PR TITLE
accept lang=xml in template as html only

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -546,6 +546,9 @@ module.exports = function (content) {
   }
 
   function getRawLoaderString (type, part, index, scoped) {
+    if (type === 'template' && part.lang === 'xml') {
+      part.lang = 'html' 
+    }
     let lang = part.lang || defaultLang[type]
 
     let styleCompiler = ''


### PR DESCRIPTION
This allows us to write
```
<template lang=xml>
...
</template>
```
Which makes IDEs syntax highlight better. 
Most IDEs are configured to treat <template> part of .vue files as HTML, and Nativescript components are not considered valid DOM elements.